### PR TITLE
Implement alias publishing for cadquery-ocp

### DIFF
--- a/util/package_index.py
+++ b/util/package_index.py
@@ -63,9 +63,9 @@ def create_renamed_wheel(original_wheel: Path, new_name: str) -> Path:
             if metadata_file.exists():
                 # Read and modify metadata
                 content = metadata_file.read_text()
-                lines = content.split('\n')com
-                    else:
-                        new_lines.append(line)
+                lines = content.split('\n')
+            else:
+                new_lines.append(line)
                 metadata_file.write_text('\n'.join(new_lines))
             
             # Rename .dist-info directory

--- a/util/package_index.py
+++ b/util/package_index.py
@@ -76,6 +76,18 @@ def build_static_repo(wheel_dirs: List[str], output_dir: str, base_url: str) -> 
             if new_wheel_path is not None:
                 new_wheel_path.unlink()
                 new_wheel_path = None
+            
+            # Publish cadquery-ocp as cadquery-ocp-novtk alias (they're the same, VTK already removed)
+            if norm_name == 'cadquery-ocp':
+                novtk_name = 'cadquery-ocp-novtk'
+                novtk_wheel_name = wheel_path.name.replace('cadquery_ocp', 'cadquery_ocp_novtk', 1)
+                packages[novtk_name].add(novtk_wheel_name)
+                
+                novtk_pkg_path = out_path / novtk_name
+                novtk_pkg_path.mkdir(parents=True, exist_ok=True)
+                novtk_dest_path = novtk_pkg_path / novtk_wheel_name
+                shutil.copy2(dest_path, novtk_dest_path)
+                log.info(f"  ↳ Also publishing as {novtk_name} (alias)")
 
     with (out_path / "index.html").open("w") as f_index_all:
         f_index_all.write('<!DOCTYPE html><html><head><title>OCP.wasm wheel registry</title></head><body>\n')

--- a/util/package_index.py
+++ b/util/package_index.py
@@ -64,8 +64,12 @@ def create_renamed_wheel(original_wheel: Path, new_name: str) -> Path:
                 # Read and modify metadata
                 content = metadata_file.read_text()
                 lines = content.split('\n')
-            else:
-                new_lines.append(line)
+                new_lines = []
+                for line in lines:
+                    if line.startswith('Name:'):
+                        new_lines.append(f'Name: {new_name}')
+                    else:
+                        new_lines.append(line)
                 metadata_file.write_text('\n'.join(new_lines))
             
             # Rename .dist-info directory


### PR DESCRIPTION
Added logic to publish cadquery-ocp as an alias cadquery-ocp-novtk, including copying the wheel file to the new path.