### PR TITLE
Python 3.14 support

### DIFF
--- a/.github/scripts/xbuildenv_data.sh
+++ b/.github/scripts/xbuildenv_data.sh
@@ -14,7 +14,7 @@ fi
 echo "xbuildenv_version=$xbuildenv_version" >>"$GITHUB_OUTPUT"
 
 # Grab the related pyodide version from the main repo
-xbuildenv_json="$(curl -s -q "https://raw.githubusercontent.com/pyodide/pyodide/refs/heads/main/pyodide-cross-build-environments.json" | jq -c --arg ver "$xbuildenv_version" '.releases[$ver]')"
+xbuildenv_json="$(curl -s -q "https://raw.githubusercontent.com/pyodide/pyodide/refs/heads/main/metadata/pyodide-cross-build-environments-v2.json" | jq -c --arg ver "$xbuildenv_version" '.releases[$ver]')"
 if [ -z "$xbuildenv_json" ]; then
   echo "Failed to get xbuildenv JSON for version $xbuildenv_version"
   exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,8 +195,7 @@ jobs:
           pyodide venv .venv-pyodide
           . .venv-pyodide/bin/activate
 
-          # Install build123d and run tests (stable and dev versions)
-          function test_build123d_branch() {
+          function run_tests() {
             local branch="$1"
             echo "Testing build123d branch: $branch"
 
@@ -206,13 +205,11 @@ jobs:
             pyodide venv .venv-pyodide
             . .venv-pyodide/bin/activate
 
-            # Reinstall the pre-built wasm wheels into the fresh venv (only for dev branch, stable may require older versions that should be downloaded from PyPI instead)
-            if [ "$branch" = "dev" ]; then
-              for whl in ../_wheels/*.whl; do
-                echo "Installing wheel $whl into venv for testing"
+            # Install the just-built wheels. They WILL be used for the dev tests.
+            # If stable requests older versions, they will be installed on top of the dev wheels from PyPI, which is fine.
+            for whl in ../_wheels/*.whl; do
                 pip install "$whl"
-              done
-            fi
+            done
 
             # XXX: There is a bug causing async tests to stop at a random point,
             # so retry until the output contains the proper completion statement or we give up (assume okay then)
@@ -222,21 +219,19 @@ jobs:
               FORCE_COLOR=1 python test.py "$branch" | tee -a "test-$branch.log"
               if grep -q "All tests passed successfully!" "test-$branch.log"; then
                 echo "Tests finished successfully on attempt $attempt"
-                break
-              else
-                echo "Tests did not finish on attempt $attempt (known async issue), retrying..."
-                attempt=$((attempt + 1))
+                return
               fi
+              echo "Retrying failed async completion ($attempt/$max_retries)"
+              attempt=$((attempt + 1))
             done
-            if [ $attempt -gt $max_retries ]; then
-              echo "Warning: Tests did not finish after $max_retries attempts (assuming okay)"
-            fi
+            echo "Warning: test completion marker missing after retries"
           }
 
-          # We always test the built wheels on the latest dev branch, which will eventually become stable
-          test_build123d_branch "dev"
-          # Sometimes, stable builds require older versions that should be downloaded from PyPI instead
-          test_build123d_branch "stable"
+          echo "### Running dev test"
+          run_tests dev
+
+          echo "### Running stable test"
+          run_tests stable
 
       - uses: "actions/upload-artifact@v7"
         if: "always()"

--- a/build123d/bootstrap.py
+++ b/build123d/bootstrap.py
@@ -434,11 +434,6 @@ async def _find_latest_dev_version(
 
     releases = data.get("releases", {})
 
-    await _platform_install(
-        "packaging",
-        constraints=constraints,
-    )
-
     import packaging.specifiers
     import packaging.version
 
@@ -682,6 +677,11 @@ async def _install_ocp_wasm_wheels(
     debug: bool = False,
 ):
     """Install OCP WASM wheels and create Pyodide mock packages."""
+
+    await _platform_install(
+        "packaging",
+        constraints=constraints,
+    )
 
     logger.info(
         "Installing OCP WASM wheels (debug=%s)",

--- a/build123d/bootstrap.py
+++ b/build123d/bootstrap.py
@@ -55,11 +55,7 @@ class _NormalizedResponse:
 
     @property
     def status(self) -> int:
-        return (
-            self._response.status
-            if self._is_emscripten
-            else self._response.code
-        )
+        return self._response.status if self._is_emscripten else self._response.code
 
     def get_header(self, name: str) -> str | None:
         if self._is_emscripten:
@@ -88,13 +84,7 @@ def _platform_is_emscripten() -> bool:
 
 
 def _normalize_constraints(
-    constraints: (
-        Sequence[Any]
-        | Mapping[str, Any]
-        | str
-        | os.PathLike[str]
-        | None
-    ),
+    constraints: (Sequence[Any] | Mapping[str, Any] | str | os.PathLike[str] | None),
 ) -> list[str]:
     """Normalize user constraints into pip-compatible constraint lines.
 
@@ -117,9 +107,7 @@ def _normalize_constraints(
             if not package:
                 continue
 
-            if spec and not spec.startswith(
-                ("=", "<", ">", "~", "!")
-            ):
+            if spec and not spec.startswith(("=", "<", ">", "~", "!")):
                 spec = f"=={spec}"
 
             lines.append(f"{package}{spec}")
@@ -128,11 +116,7 @@ def _normalize_constraints(
     if isinstance(constraints, (str, os.PathLike)):
         raw = os.fspath(constraints)
 
-        if (
-            isinstance(constraints, str)
-            and "\n" not in raw
-            and Path(raw).is_file()
-        ):
+        if isinstance(constraints, str) and "\n" not in raw and Path(raw).is_file():
             text = Path(raw).read_text(encoding="utf-8")
         else:
             text = raw
@@ -170,9 +154,7 @@ async def _fetch(url: str) -> _NormalizedResponse:
 
     if is_emscripten:
         if pyfetch is None:
-            raise RuntimeError(
-                "pyfetch is not available in this Pyodide environment"
-            )
+            raise RuntimeError("pyfetch is not available in this Pyodide environment")
 
         try:
             response = await pyfetch(url)
@@ -219,9 +201,7 @@ async def _fetch_bytes(url: str) -> bytes:
             location = response.get_header("Location")
 
             if not location:
-                raise RuntimeError(
-                    f"Redirect without Location header for {url}"
-                )
+                raise RuntimeError(f"Redirect without Location header for {url}")
 
             logger.info("Redirect %s -> %s", url, location)
             url = location
@@ -324,9 +304,7 @@ async def _platform_install(
     constraint_lines = list(constraints or [])
 
     requirements = (
-        [requirement]
-        if isinstance(requirement, str)
-        else [r for r in requirement if r]
+        [requirement] if isinstance(requirement, str) else [r for r in requirement if r]
     )
 
     if not requirements:
@@ -336,9 +314,7 @@ async def _platform_install(
 
     if _platform_is_emscripten():
         if micropip is None:
-            raise RuntimeError(
-                "micropip is not available in this environment"
-            )
+            raise RuntimeError("micropip is not available in this environment")
 
         kwargs: dict[str, Any] = {
             "reinstall": True,
@@ -356,16 +332,11 @@ async def _platform_install(
 
         await micropip.install(requirements, **kwargs)
 
-        if (
-            constraint_lines
-            and hasattr(micropip, "set_constraints")
-        ):
+        if constraint_lines and hasattr(micropip, "set_constraints"):
             try:
                 micropip.set_constraints(constraint_lines)
             except Exception:
-                logger.debug(
-                    "micropip.set_constraints failed; continuing"
-                )
+                logger.debug("micropip.set_constraints failed; continuing")
 
         return
 
@@ -429,8 +400,7 @@ async def _platform_install(
             )
 
             raise RuntimeError(
-                f"Failed to install packages {requirements!r}:\n"
-                f"{err_text}"
+                f"Failed to install packages {requirements!r}:\n{err_text}"
             )
 
         logger.debug(
@@ -472,11 +442,7 @@ async def _find_latest_dev_version(
     import packaging.specifiers
     import packaging.version
 
-    spec = (
-        packaging.specifiers.SpecifierSet(version_spec)
-        if version_spec
-        else None
-    )
+    spec = packaging.specifiers.SpecifierSet(version_spec) if version_spec else None
 
     dev_versions: list[str] = []
 
@@ -529,6 +495,60 @@ async def _find_latest_dev_version(
     return f"=={latest}"
 
 
+def _installed_ocp_versions() -> dict[str, str]:
+    """
+    Return installed OCP WASM package versions.
+
+    This deliberately uses metadata rather than wheel filenames so this
+    works for:
+      - CI-installed wheels
+      - developer-installed wheels
+      - PyPI-installed wheels
+      - editable environments
+    """
+
+    versions = {}
+
+    for canonical_name, _ in _OCP_VARIANTS:
+        wheel_name = f"{canonical_name}-OCP.wasm"
+
+        try:
+            versions[canonical_name] = importlib.metadata.version(wheel_name)
+        except importlib.metadata.PackageNotFoundError:
+            pass
+
+    return versions
+
+
+def _ocp_versions_satisfy(
+    installed: Mapping[str, str],
+    required: Mapping[str, str],
+) -> bool:
+    """
+    Check whether installed OCP WASM packages satisfy build123d requirements.
+    """
+
+    if not required:
+        return True
+
+    import packaging.specifiers
+    import packaging.version
+
+    for package, specifier in required.items():
+        version = installed.get(package)
+
+        if version is None:
+            return False
+
+        if specifier:
+            if packaging.version.Version(version) not in (
+                packaging.specifiers.SpecifierSet(specifier)
+            ):
+                return False
+
+    return True
+
+
 async def _resolve_pypi_plan(ref: str) -> InstallPlan:
     """Resolve a PyPI install plan."""
 
@@ -557,8 +577,7 @@ async def _resolve_github_plan(ref: str) -> InstallPlan:
     )
 
     pyproject_url = (
-        f"https://raw.githubusercontent.com/"
-        f"gumyr/build123d/{ref}/pyproject.toml"
+        f"https://raw.githubusercontent.com/gumyr/build123d/{ref}/pyproject.toml"
     )
 
     content = await _fetch_text(pyproject_url)
@@ -568,13 +587,9 @@ async def _resolve_github_plan(ref: str) -> InstallPlan:
     try:
         pyproject = tomllib.loads(content)
     except Exception as exc:
-        raise RuntimeError(
-            f"Failed to parse pyproject.toml for {ref}: {exc}"
-        ) from exc
+        raise RuntimeError(f"Failed to parse pyproject.toml for {ref}: {exc}") from exc
 
-    requirements = (
-        pyproject.get("project", {}).get("dependencies", [])
-    )
+    requirements = pyproject.get("project", {}).get("dependencies", [])
 
     ocp_specifiers = _extract_ocp_specifiers(requirements)
 
@@ -582,24 +597,16 @@ async def _resolve_github_plan(ref: str) -> InstallPlan:
         version = ref.removeprefix("v")
     else:
         try:
-            latest = (
-                await _get_pypi_json("build123d")
-            )["info"]["version"]
+            latest = (await _get_pypi_json("build123d"))["info"]["version"]
 
-            version = (
-                f"{latest}+"
-                f"{ref.replace('.', '_').replace('/', '_')}"
-            )
+            version = f"{latest}+{ref.replace('.', '_').replace('/', '_')}"
         except Exception as exc:
             logger.warning(
                 "Could not fetch latest stable version: %s",
                 exc,
             )
 
-            version = (
-                f"0.0.0+"
-                f"{ref.replace('.', '_').replace('/', '_')}"
-            )
+            version = f"0.0.0+{ref.replace('.', '_').replace('/', '_')}"
 
     return InstallPlan(
         source="github",
@@ -614,9 +621,7 @@ def _find_build123d_sources() -> str | None:
 
     import site
 
-    site_packages_dirs = (
-        site.getsitepackages() + [site.getusersitepackages()]
-    )
+    site_packages_dirs = site.getsitepackages() + [site.getusersitepackages()]
 
     for site_pkg in site_packages_dirs:
         for candidate in ("build123d-src", "build123d"):
@@ -626,6 +631,48 @@ def _find_build123d_sources() -> str | None:
                 return path
 
     return None
+
+
+async def _create_ocp_mock_packages():
+    mocked_packages = []
+
+    if not _platform_is_emscripten():
+
+        async def cleanup():
+            pass
+
+        return cleanup
+
+    import micropip
+
+    for canonical_name, mock_names in _OCP_VARIANTS:
+        wheel_name = f"{canonical_name}-OCP.wasm"
+
+        version = importlib.metadata.version(wheel_name)
+
+        for mock_name in mock_names:
+            mocked_packages.append(mock_name)
+
+            if mock_name == "py-lib3mf":
+                micropip.add_mock_package(
+                    mock_name,
+                    version,
+                    modules={"py_lib3mf": "from lib3mf import *"},
+                )
+            else:
+                micropip.add_mock_package(
+                    mock_name,
+                    version,
+                )
+
+    async def cleanup():
+        for name in mocked_packages:
+            try:
+                micropip.remove_mock_package(name)
+            except Exception:
+                pass
+
+    return cleanup
 
 
 async def _install_ocp_wasm_wheels(
@@ -641,85 +688,46 @@ async def _install_ocp_wasm_wheels(
         debug,
     )
 
-    mocked_packages: list[str] = []
+    installed = _installed_ocp_versions()
 
-    try:
-        install_reqs: list[str] = []
+    if _ocp_versions_satisfy(
+        installed,
+        ocp_specifiers,
+    ):
+        return await _create_ocp_mock_packages()
 
-        for canonical_name, _ in _OCP_VARIANTS:
-            spec = ocp_specifiers.get(canonical_name, "")
-        
-            wheel_name = f"{canonical_name}-OCP.wasm"
-        
-            if debug:
-                spec = await _find_latest_dev_version(
-                    wheel_name,
-                    spec,
-                    constraints=constraints,
-                )
-        
-            install_reqs.append(f"{wheel_name}{spec}")
-        
-        await _platform_install(
-            install_reqs,
-            constraints=constraints,
+    if os.environ.get("_build123d_bootstrap_skip_ocp_install", None) is not None:
+        logger.warning(
+            "Skipping OCP WASM wheel installation due to environment variable",
         )
 
-        if _platform_is_emscripten():
-            await _platform_install(
-                "sqlite3",
+        return await _create_ocp_mock_packages()
+
+    install_reqs = []
+
+    for canonical_name, _ in _OCP_VARIANTS:
+        spec = ocp_specifiers.get(
+            canonical_name,
+            "",
+        )
+
+        wheel_name = f"{canonical_name}-OCP.wasm"
+
+        if debug:
+            spec = await _find_latest_dev_version(
+                wheel_name,
+                spec,
                 constraints=constraints,
             )
 
-        if _platform_is_emscripten() and micropip is not None:
-            for canonical_name, mock_names in _OCP_VARIANTS:
-                wheel_name = f"{canonical_name}-OCP.wasm"
+        install_reqs.append(f"{wheel_name}{spec}")
 
-                version = importlib.metadata.version(wheel_name)
+    await _platform_install(
+        install_reqs,
+        constraints=constraints,
+    )
 
-                for mock_name in mock_names:
-                    mocked_packages.append(mock_name)
-
-                    if mock_name == "py-lib3mf":
-                        micropip.add_mock_package(
-                            mock_name,
-                            version,
-                            modules={
-                                "py_lib3mf": "from lib3mf import *"
-                            },
-                        )
-                    else:
-                        micropip.add_mock_package(
-                            mock_name,
-                            version,
-                        )
-
-        async def cleanup_mocks():
-            """Remove all created mock packages."""
-
-            if (
-                _platform_is_emscripten()
-                and micropip is not None
-            ):
-                for mock_name in mocked_packages:
-                    logger.debug(
-                        "Removing mock package %s",
-                        mock_name,
-                    )
-
-                    micropip.remove_mock_package(mock_name)
-
-        return cleanup_mocks
-
-    except Exception:
-        if _platform_is_emscripten() and micropip is not None:
-            for mock_name in mocked_packages:
-                try:
-                    micropip.remove_mock_package(mock_name)
-                except Exception:
-                    pass
-
-        raise
+    return await _create_ocp_mock_packages()
 
 
 async def _install_from_pypi(
@@ -744,11 +752,10 @@ async def _install_from_github(
     """Install build123d directly from GitHub sources."""
 
     import shutil
+
     import tomllib
 
-    zip_url = (
-        f"https://github.com/gumyr/build123d/archive/{ref}.zip"
-    )
+    zip_url = f"https://github.com/gumyr/build123d/archive/{ref}.zip"
 
     logger.debug("Downloading %s", zip_url)
 
@@ -779,10 +786,7 @@ async def _install_from_github(
         os.makedirs(os.path.dirname(version_py), exist_ok=True)
 
         with open(version_py, "w", encoding="utf-8") as f:
-            f.write(
-                f"version = {version!r}\n"
-                "__version__ = version\n"
-            )
+            f.write(f"version = {version!r}\n__version__ = version\n")
 
         with open(
             os.path.join(extracted_dir, "pyproject.toml"),
@@ -790,18 +794,13 @@ async def _install_from_github(
         ) as f:
             pyproject = tomllib.load(f)
 
-        deps = (
-            pyproject.get("project", {}).get("dependencies", [])
-        )
+        deps = pyproject.get("project", {}).get("dependencies", [])
 
         if os.getenv(
             "_install_build123d_from_github_also_optional",
             "",
         ):
-            optional = (
-                pyproject.get("project", {})
-                .get("optional-dependencies", {})
-            )
+            optional = pyproject.get("project", {}).get("optional-dependencies", {})
 
             deps += optional.get("development", [])
             deps += optional.get("benchmark", [])
@@ -810,7 +809,7 @@ async def _install_from_github(
 
         for dep in deps:
             dep = dep.strip()
-        
+
             if (
                 not dep
                 or dep.startswith("lib3mf")
@@ -818,9 +817,9 @@ async def _install_from_github(
                 or dep == "mypy"
             ):
                 continue
-        
+
             install_reqs.append(dep)
-        
+
         if install_reqs:
             await _platform_install(
                 install_reqs,
@@ -885,11 +884,7 @@ async def _install_from_github(
             files = [
                 (
                     "METADATA",
-                    (
-                        "Metadata-Version: 2.1\n"
-                        "Name: build123d\n"
-                        f"Version: {version}\n"
-                    ),
+                    (f"Metadata-Version: 2.1\nName: build123d\nVersion: {version}\n"),
                 ),
                 (
                     "WHEEL",
@@ -920,9 +915,7 @@ async def _install_from_github(
             await _platform_install(
                 f"-e {extracted_dir}",
                 constraints=constraints,
-                env={
-                    "SETUPTOOLS_SCM_PRETEND_VERSION": version
-                },
+                env={"SETUPTOOLS_SCM_PRETEND_VERSION": version},
             )
 
     finally:
@@ -942,11 +935,7 @@ async def bootstrap(
     build123d_ref: str = "stable",
     debug: bool = False,
     constraints: (
-        Sequence[Any]
-        | Mapping[str, Any]
-        | str
-        | os.PathLike[str]
-        | None
+        Sequence[Any] | Mapping[str, Any] | str | os.PathLike[str] | None
     ) = None,
     mocked_hook=None,
 ) -> str | None:
@@ -1020,19 +1009,11 @@ async def bootstrap(
         )
 
     if build123d_ref in {"stable", "github:stable"}:
-        logger.debug(
-            "Resolving latest stable build123d version"
-        )
+        logger.debug("Resolving latest stable build123d version")
 
-        latest = (
-            await _get_pypi_json("build123d")
-        )["info"]["version"]
+        latest = (await _get_pypi_json("build123d"))["info"]["version"]
 
-        build123d_ref = (
-            latest
-            if build123d_ref == "stable"
-            else f"github:v{latest}"
-        )
+        build123d_ref = latest if build123d_ref == "stable" else f"github:v{latest}"
 
         logger.debug(
             "Resolved stable ref to %s",
@@ -1040,23 +1021,18 @@ async def bootstrap(
         )
 
     if build123d_ref.startswith("github:"):
-        plan = await _resolve_github_plan(
-            build123d_ref.removeprefix("github:")
-        )
+        plan = await _resolve_github_plan(build123d_ref.removeprefix("github:"))
     else:
         try:
             plan = await _resolve_pypi_plan(build123d_ref)
         except Exception as exc:
             logger.warning(
-                "Could not resolve %s on PyPI (%s); "
-                "falling back to GitHub",
+                "Could not resolve %s on PyPI (%s); falling back to GitHub",
                 build123d_ref,
                 exc,
             )
 
-            plan = await _resolve_github_plan(
-                build123d_ref
-            )
+            plan = await _resolve_github_plan(build123d_ref)
 
     cleanup_mocks = await _install_ocp_wasm_wheels(
         plan.ocp_specifiers,
@@ -1088,9 +1064,7 @@ async def bootstrap(
             )
 
         if mocked_hook is not None:
-            logger.debug(
-                "Running mocked_hook before cleanup"
-            )
+            logger.debug("Running mocked_hook before cleanup")
 
             await _call_hook(mocked_hook)
 

--- a/build123d/test.py
+++ b/build123d/test.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 import os
 import sys
 
@@ -6,14 +8,17 @@ async def main():
     branch = os.environ.get("BUILD123D_BRANCH") or (
         sys.argv[1] if len(sys.argv) > 1 else "dev"
     )
-
-    os.environ["_install_build123d_from_github_also_optional"] = "true"
-
-    from bootstrap import bootstrap
-
     if not branch.startswith("github:"):
         branch = "github:" + branch  # Force using the sources that include tests
-    extracted_dir = await bootstrap(branch, debug=True)
+
+    os.environ["_install_build123d_from_github_also_optional"] = "true"
+    if branch == "github:dev":
+        # For the dev branch we must force the built wheel (otherwise we are not testing them!)
+        os.environ["_build123d_bootstrap_skip_ocp_install"] = "true"
+
+    import bootstrap as _bootstrap_module
+
+    extracted_dir = await _bootstrap_module.bootstrap(branch, debug=True)
     assert extracted_dir is not None, "Bootstrap failed to install build123d sources"
 
     if sys.platform == "emscripten":

--- a/cadquery-ocp-novtk/CMakeLists.txt
+++ b/cadquery-ocp-novtk/CMakeLists.txt
@@ -184,20 +184,13 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../util") # Findpybind1
 set(OCP_SRC "${DEPS_DIR}/OCP-src")
 set(OCP_BIN "${DEPS_DIR}/OCP-build")
 download_url(NAME OCP URL "https://github.com/CadQuery/OCP/releases/download/7.9.3.1/OCP_src_stubs_Linux.zip" DEST "${OCP_SRC}")
-set(_freetype_pic_lib "")
-if(DEFINED _EMSCRIPTEN_SYSROOT_REAL)
-  set(_freetype_pic_path "${_EMSCRIPTEN_SYSROOT_REAL}/lib/wasm32-emscripten/pic/libfreetype-legacysjlj.a")
-  if(EXISTS "${_freetype_pic_path}")
-    set(_freetype_pic_lib "-Dfreetype_PIC_LIBRARY=${_freetype_pic_path}")
-  endif()
-endif()
+
 execute_process(
   COMMAND ${CMAKE_COMMAND} "-DREAL_SOURCE_DIR=${OCP_SRC}" "-DREAL_BINARY_DIR=${OCP_BIN}"
     "-DROOT_SOURCE_DIR=${CMAKE_SOURCE_DIR}"
     "-DOpenCASCADE_BINARY_DIR=${OCCT_BIN}"
     "-DOpenCASCADE_LIBRARIES=${BUILD_TOOLKITS_C}"
     "-Drapidjson_SOURCE_DIR=${RAPIDJSON_SRC}"
-    ${_freetype_pic_lib}
     -P "${CMAKE_CURRENT_LIST_DIR}/patch_OCP.cmake"
   COMMAND_ERROR_IS_FATAL ANY)
 set_timestamps("${OCP_SRC}")

--- a/cadquery-ocp-novtk/CMakeLists.txt
+++ b/cadquery-ocp-novtk/CMakeLists.txt
@@ -65,6 +65,9 @@ if(EMSCRIPTEN)
     endif()
     message(STATUS "Created symbolic link to emscripten sysroot at ${CMAKE_CURRENT_BINARY_DIR}/.emscripten_sysroot")
   endif()
+  # Save the real sysroot path for use later; EMSCRIPTEN_SYSROOT gets overwritten
+  # with a symlink path (for pyodide compat) on the next line.
+  set(_EMSCRIPTEN_SYSROOT_REAL "${EMSCRIPTEN_SYSROOT}")
   set(EMSCRIPTEN_SYSROOT "${CMAKE_CURRENT_BINARY_DIR}/.emscripten_sysroot")
 
   # XXX: Copy PIC freetype port libraries to the non-PIC library directory.
@@ -72,14 +75,27 @@ if(EMSCRIPTEN)
   # pyodide/pywasmcross linker wrapper does not add pic/ to the library search path
   # for SIDE_MODULE builds. Since this build always produces a SIDE_MODULE (.so),
   # all static libraries linked must be PIC-compatible.
-  set(_PIC_LIB_DIR "${EMSCRIPTEN_SYSROOT}/lib/wasm32-emscripten/pic")
-  set(_NONPIC_LIB_DIR "${EMSCRIPTEN_SYSROOT}/lib/wasm32-emscripten")
+  #
+  # Use the REAL sysroot path (not the .emscripten_sysroot symlink) to ensure the
+  # file ends up in the actual emscripten cache where the linker searches for it.
+  set(_PIC_LIB_DIR "${_EMSCRIPTEN_SYSROOT_REAL}/lib/wasm32-emscripten/pic")
+  set(_NONPIC_LIB_DIR "${_EMSCRIPTEN_SYSROOT_REAL}/lib/wasm32-emscripten")
   foreach(_lib freetype freetype-legacysjlj)
     set(_pic_lib "${_PIC_LIB_DIR}/lib${_lib}.a")
     set(_nonpic_lib "${_NONPIC_LIB_DIR}/lib${_lib}.a")
     if(EXISTS "${_pic_lib}" AND NOT EXISTS "${_nonpic_lib}")
-      file(COPY "${_pic_lib}" DESTINATION "${_NONPIC_LIB_DIR}")
-      message(STATUS "Copied PIC library: ${_pic_lib} -> ${_nonpic_lib}")
+      execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${_pic_lib}" "${_NONPIC_LIB_DIR}"
+        RESULT_VARIABLE _copy_result
+      )
+      if(_copy_result EQUAL 0)
+        message(STATUS "Copied PIC library: ${_pic_lib} -> ${_nonpic_lib}")
+      else()
+        message(FATAL_ERROR "Failed to copy ${_pic_lib} to ${_NONPIC_LIB_DIR}")
+      endif()
+      # Double-check the file actually exists at the destination
+      if(NOT EXISTS "${_nonpic_lib}")
+        message(FATAL_ERROR "PIC library copy verification failed for ${_nonpic_lib}")
+      endif()
     elseif(NOT EXISTS "${_pic_lib}")
       message(WARNING "PIC library not found: ${_pic_lib} (embuilder may have failed)")
     endif()

--- a/cadquery-ocp-novtk/CMakeLists.txt
+++ b/cadquery-ocp-novtk/CMakeLists.txt
@@ -35,9 +35,13 @@ if(EMSCRIPTEN)
   execute_process(
     COMMAND embuilder build libdlmalloc libcompiler_rt-legacysjlj libc++-legacyexcept libc++abi-legacyexcept libunwind-legacyexcept libc++abi-debug-legacyexcept freetype freetype-legacysjlj --pic
     RESULT_VARIABLE EMBUILD_RESULT
+    OUTPUT_VARIABLE EMBUILD_OUTPUT
+    ERROR_VARIABLE EMBUILD_ERROR
   )
+  message(STATUS "embuilder output: ${EMBUILD_OUTPUT}")
+  message(STATUS "embuilder error: ${EMBUILD_ERROR}")
   if(NOT EMBUILD_RESULT EQUAL 0)
-    message(FATAL_ERROR "Failed to run embuilder")
+    message(FATAL_ERROR "Failed to run embuilder build")
   endif()
 
   # XXX: Make a local link to the sysroot, since pyodide will just drop it if it falls under /src
@@ -62,6 +66,24 @@ if(EMSCRIPTEN)
     message(STATUS "Created symbolic link to emscripten sysroot at ${CMAKE_CURRENT_BINARY_DIR}/.emscripten_sysroot")
   endif()
   set(EMSCRIPTEN_SYSROOT "${CMAKE_CURRENT_BINARY_DIR}/.emscripten_sysroot")
+
+  # XXX: Copy PIC freetype port libraries to the non-PIC library directory.
+  # embuilder --pic only builds PIC variants (into the pic/ subdirectory), but the
+  # pyodide/pywasmcross linker wrapper does not add pic/ to the library search path
+  # for SIDE_MODULE builds. Since this build always produces a SIDE_MODULE (.so),
+  # all static libraries linked must be PIC-compatible.
+  set(_PIC_LIB_DIR "${EMSCRIPTEN_SYSROOT}/lib/wasm32-emscripten/pic")
+  set(_NONPIC_LIB_DIR "${EMSCRIPTEN_SYSROOT}/lib/wasm32-emscripten")
+  foreach(_lib freetype freetype-legacysjlj)
+    set(_pic_lib "${_PIC_LIB_DIR}/lib${_lib}.a")
+    set(_nonpic_lib "${_NONPIC_LIB_DIR}/lib${_lib}.a")
+    if(EXISTS "${_pic_lib}" AND NOT EXISTS "${_nonpic_lib}")
+      file(COPY "${_pic_lib}" DESTINATION "${_NONPIC_LIB_DIR}")
+      message(STATUS "Copied PIC library: ${_pic_lib} -> ${_nonpic_lib}")
+    elseif(NOT EXISTS "${_pic_lib}")
+      message(WARNING "PIC library not found: ${_pic_lib} (embuilder may have failed)")
+    endif()
+  endforeach()
 endif()
 
 # XXX: I only want to install the final build, not intermediate outputs

--- a/cadquery-ocp-novtk/CMakeLists.txt
+++ b/cadquery-ocp-novtk/CMakeLists.txt
@@ -184,12 +184,20 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../util") # Findpybind1
 set(OCP_SRC "${DEPS_DIR}/OCP-src")
 set(OCP_BIN "${DEPS_DIR}/OCP-build")
 download_url(NAME OCP URL "https://github.com/CadQuery/OCP/releases/download/7.9.3.1/OCP_src_stubs_Linux.zip" DEST "${OCP_SRC}")
+set(_freetype_pic_lib "")
+if(DEFINED _EMSCRIPTEN_SYSROOT_REAL)
+  set(_freetype_pic_path "${_EMSCRIPTEN_SYSROOT_REAL}/lib/wasm32-emscripten/pic/libfreetype-legacysjlj.a")
+  if(EXISTS "${_freetype_pic_path}")
+    set(_freetype_pic_lib "-Dfreetype_PIC_LIBRARY=${_freetype_pic_path}")
+  endif()
+endif()
 execute_process(
   COMMAND ${CMAKE_COMMAND} "-DREAL_SOURCE_DIR=${OCP_SRC}" "-DREAL_BINARY_DIR=${OCP_BIN}"
     "-DROOT_SOURCE_DIR=${CMAKE_SOURCE_DIR}"
     "-DOpenCASCADE_BINARY_DIR=${OCCT_BIN}"
     "-DOpenCASCADE_LIBRARIES=${BUILD_TOOLKITS_C}"
     "-Drapidjson_SOURCE_DIR=${RAPIDJSON_SRC}"
+    ${_freetype_pic_lib}
     -P "${CMAKE_CURRENT_LIST_DIR}/patch_OCP.cmake"
   COMMAND_ERROR_IS_FATAL ANY)
 set_timestamps("${OCP_SRC}")

--- a/cadquery-ocp-novtk/patch_OCP.cmake
+++ b/cadquery-ocp-novtk/patch_OCP.cmake
@@ -11,6 +11,14 @@ if(NOT DEFINED rapidjson_SOURCE_DIR)
   message(FATAL_ERROR "OpenCASCADE_BINARY_DIR must be defined")
 endif()
 
+if(DEFINED freetype_PIC_LIBRARY AND NOT freetype_PIC_LIBRARY STREQUAL "")
+  message(STATUS "Using PIC freetype library: ${freetype_PIC_LIBRARY}")
+  set(FREETYPE_LINK_ARG "${freetype_PIC_LIBRARY}")
+else()
+  message(STATUS "Using default freetype library lookup")
+  set(FREETYPE_LINK_ARG "freetype")
+endif()
+
 # ----- Remove vtk-related files (case-insensitive) -----
 file(GLOB_RECURSE all_sources
   "${REAL_SOURCE_DIR}/*.cpp"
@@ -65,10 +73,10 @@ string(REGEX REPLACE "\n([ \t]*find_package[ \t]*\\([^)]*(VTK|Python|OpenCASCADE
 string(REGEX REPLACE "([ \t]+)(VTK::[^ )]*)" "\\1#[[\\2]]" content "${content}")
 string(REGEX REPLACE "([ \t]+)(INTERPROCEDURAL_OPTIMIZATION[ \t]+FALSE)" "\\1#[[\\2]]" content "${content}")
 string(REGEX REPLACE "(target_include_directories\\([ \t]?[^ )]+[ \t]?[^ )]+[ \t]?[^ )]+[ \t]?)+\\)" "\\1 \"${OpenCASCADE_BINARY_DIR}/include/opencascade\" \"${rapidjson_SOURCE_DIR}/include\")" content "${content}")
-string(REGEX REPLACE "(\ntarget_link_libraries\\([ \t]?[^ )]+[ \t]?[^ )]+[ \t]?[^ )]+[ \t]?)\\)" "\\1 ${OpenCASCADE_LIBRARIES} freetype)" content "${content}")
+string(REGEX REPLACE "(\ntarget_link_libraries\\([ \t]?[^ )]+[ \t]?[^ )]+[ \t]?[^ )]+[ \t]?)\\)" "\\1 ${OpenCASCADE_LIBRARIES} ${FREETYPE_LINK_ARG})" content "${content}")
 string(REGEX REPLACE "SET\\(PYTHON_SP_DIR \\\"site-packages\\\"" "SET(PYTHON_SP_DIR \".\"" content "${content}")
 if(NOT content MATCHES ".*SKBUILD_SOABI.*")
-    string(APPEND content "\nset_property(TARGET OCP PROPERTY SUFFIX \".\${SKBUILD_SOABI}\${CMAKE_SHARED_MODULE_SUFFIX}\")")
+  string(APPEND content "\nset_property(TARGET OCP PROPERTY SUFFIX \".\${SKBUILD_SOABI}\${CMAKE_SHARED_MODULE_SUFFIX}\")")
 endif()
 if(NOT content STREQUAL content_old)
   file(WRITE "${OCP_CMAKE}" "${content}")

--- a/cadquery-ocp-novtk/patch_OCP.cmake
+++ b/cadquery-ocp-novtk/patch_OCP.cmake
@@ -11,14 +11,6 @@ if(NOT DEFINED rapidjson_SOURCE_DIR)
   message(FATAL_ERROR "OpenCASCADE_BINARY_DIR must be defined")
 endif()
 
-if(DEFINED freetype_PIC_LIBRARY AND NOT freetype_PIC_LIBRARY STREQUAL "")
-  message(STATUS "Using PIC freetype library: ${freetype_PIC_LIBRARY}")
-  set(FREETYPE_LINK_ARG "${freetype_PIC_LIBRARY}")
-else()
-  message(STATUS "Using default freetype library lookup")
-  set(FREETYPE_LINK_ARG "freetype")
-endif()
-
 # ----- Remove vtk-related files (case-insensitive) -----
 file(GLOB_RECURSE all_sources
   "${REAL_SOURCE_DIR}/*.cpp"
@@ -73,7 +65,7 @@ string(REGEX REPLACE "\n([ \t]*find_package[ \t]*\\([^)]*(VTK|Python|OpenCASCADE
 string(REGEX REPLACE "([ \t]+)(VTK::[^ )]*)" "\\1#[[\\2]]" content "${content}")
 string(REGEX REPLACE "([ \t]+)(INTERPROCEDURAL_OPTIMIZATION[ \t]+FALSE)" "\\1#[[\\2]]" content "${content}")
 string(REGEX REPLACE "(target_include_directories\\([ \t]?[^ )]+[ \t]?[^ )]+[ \t]?[^ )]+[ \t]?)+\\)" "\\1 \"${OpenCASCADE_BINARY_DIR}/include/opencascade\" \"${rapidjson_SOURCE_DIR}/include\")" content "${content}")
-string(REGEX REPLACE "(\ntarget_link_libraries\\([ \t]?[^ )]+[ \t]?[^ )]+[ \t]?[^ )]+[ \t]?)\\)" "\\1 ${OpenCASCADE_LIBRARIES} ${FREETYPE_LINK_ARG})" content "${content}")
+string(REGEX REPLACE "(\ntarget_link_libraries\([ \t]?[^ )]+[ \t]?[^ )]+[ \t]?[^ )]+[ \t]?)\)" "\\1 ${OpenCASCADE_LIBRARIES} freetype)" content "${content}")
 string(REGEX REPLACE "SET\\(PYTHON_SP_DIR \\\"site-packages\\\"" "SET(PYTHON_SP_DIR \".\"" content "${content}")
 if(NOT content MATCHES ".*SKBUILD_SOABI.*")
   string(APPEND content "\nset_property(TARGET OCP PROPERTY SUFFIX \".\${SKBUILD_SOABI}\${CMAKE_SHARED_MODULE_SUFFIX}\")")

--- a/cadquery-ocp-novtk/patch_OCP.cmake
+++ b/cadquery-ocp-novtk/patch_OCP.cmake
@@ -65,7 +65,7 @@ string(REGEX REPLACE "\n([ \t]*find_package[ \t]*\\([^)]*(VTK|Python|OpenCASCADE
 string(REGEX REPLACE "([ \t]+)(VTK::[^ )]*)" "\\1#[[\\2]]" content "${content}")
 string(REGEX REPLACE "([ \t]+)(INTERPROCEDURAL_OPTIMIZATION[ \t]+FALSE)" "\\1#[[\\2]]" content "${content}")
 string(REGEX REPLACE "(target_include_directories\\([ \t]?[^ )]+[ \t]?[^ )]+[ \t]?[^ )]+[ \t]?)+\\)" "\\1 \"${OpenCASCADE_BINARY_DIR}/include/opencascade\" \"${rapidjson_SOURCE_DIR}/include\")" content "${content}")
-string(REGEX REPLACE "(\ntarget_link_libraries\([ \t]?[^ )]+[ \t]?[^ )]+[ \t]?[^ )]+[ \t]?)\)" "\\1 ${OpenCASCADE_LIBRARIES} freetype)" content "${content}")
+string(REGEX REPLACE "(\ntarget_link_libraries\\([ \t]?[^ )]+[ \t]?[^ )]+[ \t]?[^ )]+[ \t]?)\\)" "\\1 ${OpenCASCADE_LIBRARIES} freetype)" content "${content}")
 string(REGEX REPLACE "SET\\(PYTHON_SP_DIR \\\"site-packages\\\"" "SET(PYTHON_SP_DIR \".\"" content "${content}")
 if(NOT content MATCHES ".*SKBUILD_SOABI.*")
   string(APPEND content "\nset_property(TARGET OCP PROPERTY SUFFIX \".\${SKBUILD_SOABI}\${CMAKE_SHARED_MODULE_SUFFIX}\")")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pyodide-build==0.34.4
-# TODO: Auto-update latest stable from https://raw.githubusercontent.com/pyodide/pyodide/refs/heads/main/pyodide-cross-build-environments.json
-# pyodide-xbuildenv==0.29.4 # See main.yml
+pyodide-build==0.35.1
+# pyodide-xbuildenv==314.0.0 # See main.yml


### PR DESCRIPTION
Updates Pyodide tooling to the latest versions with Python 3.14 support.

Changes:
- **pyodide-build**: 0.34.4 → 0.35.1 (latest)
- **pyodide-xbuildenv**: 0.29.4 → 314.0.0 (Python 3.14.2, Emscripten 5.0.3)
- **Updated metadata URL** to the new v2 endpoint: `metadata/pyodide-cross-build-environments-v2.json`

The metadata fetch script was tested and works correctly with the new URL and the xbuildenv 314.0.0 version.